### PR TITLE
Update Nexuiz Classic runtime to 23.08

### DIFF
--- a/com.alientrap.nexuiz-classic.metainfo.xml
+++ b/com.alientrap.nexuiz-classic.metainfo.xml
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2020 Richard Szibele -->
 <component type="desktop-application">
     <id>com.alientrap.nexuiz-classic</id>
@@ -45,8 +45,9 @@
             <image type="source" width="1366" height="768">https://raw.githubusercontent.com/flathub/com.alientrap.nexuiz-classic/master/screenshots/screenshot_3.jpg</image>
         </screenshot>
     </screenshots>
-    <url type="homepage">http://www.alientrap.com/games/nexuiz/</url>
+    <url type="homepage">https://www.alientrap.com/games/nexuiz/</url>
     <url type="bugtracker">https://sourceforge.net/projects/nexuiz/</url>
+    <url type="vcs-browser">https://sourceforge.net/projects/nexuiz/</url>
     <provides>
         <binary>nexuiz</binary>
     </provides>

--- a/com.alientrap.nexuiz-classic.yaml
+++ b/com.alientrap.nexuiz-classic.yaml
@@ -1,6 +1,6 @@
 app-id: com.alientrap.nexuiz-classic
 runtime: org.freedesktop.Platform
-runtime-version: "21.08"
+runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 command: launcher.sh
 finish-args:

--- a/com.alientrap.nexuiz-classic.yaml
+++ b/com.alientrap.nexuiz-classic.yaml
@@ -11,7 +11,6 @@ finish-args:
   - --persist=.nexuiz
 cleanup:
 - /include
-- /lib/debug
 - /lib/pkgconfig
 - /share/aclocal
 - /share/man


### PR DESCRIPTION
- Update Nexuiz Classic runtime to 23.08 since runtime version 21.08 has reached end-of-life.
- Fix appdata papercuts